### PR TITLE
Android PromiseUtil Log name 변경

### DIFF
--- a/android/src/main/java/com/dooboolab/naverlogin/PromiseUtils.kt
+++ b/android/src/main/java/com/dooboolab/naverlogin/PromiseUtils.kt
@@ -9,7 +9,7 @@ import com.facebook.react.bridge.Promise
  * want to crash in the case of it being resolved/rejected more than once
  */
 
-const val TAG = "IapPromises"
+const val TAG = "RNNaverLogin"
 
 fun Promise.safeResolve(value: Any?) {
     try {


### PR DESCRIPTION
TITC

기존에 `IapPromise`로 되어있던 `PromiseUtil.kt`의 로깅 네임을 `RNNaverLogin`으로 변경했습니다.