### PR TITLE
RN 0.76.0 안드로이드 빌드 에러

### DIFF
--- a/android/src/main/java/com/dooboolab/naverlogin/PromiseUtils.kt
+++ b/android/src/main/java/com/dooboolab/naverlogin/PromiseUtils.kt
@@ -39,7 +39,7 @@ fun Promise.safeReject(
     throwable: Throwable?,
 ) {
     try {
-        this.reject(code, message, throwable)
+        this.reject(code ?: "UNKNOWN_ERROR", message, throwable)
     } catch (oce: ObjectAlreadyConsumedException) {
         Log.d(TAG, "Already consumed ${oce.message}")
     }


### PR DESCRIPTION
React Native 0.76 으로 업그레이드 후 안드로이드에서 빌드 에러가 발생합니다.

```
Task :react-native-seoul_naver-login:compileReleaseKotlin FAILED e: file:///.../node_modules/@react-native-seoul/naver-login/android/src/main/java/com/dooboolab/naverlogin/PromiseUtils.kt:42:21 Type mismatch: inferred type is String? but String was expected
```

기본값을 입력하여 빌드에러를 방지하는 코드를 추가하였습니다.
Fallback Message는 일단 `UNKNOWN_ERROR` 로 하였으나 수정해도 좋을 듯 합니다.