### PR TITLE
problem with fbsdk-confict where login method should return void, not…

### DIFF
--- a/android/src/main/java/com/dooboolab/naverlogin/RNNaverLoginModule.kt
+++ b/android/src/main/java/com/dooboolab/naverlogin/RNNaverLoginModule.kt
@@ -18,11 +18,13 @@ class RNNaverLoginModule(reactContext: ReactApplicationContext) : ReactContextBa
     override fun getName() = "RNNaverLogin"
 
     @ReactMethod
-    fun logout(promise: Promise) =
+    fun logout(promise: Promise) {
+        // to change it as void type
         UiThreadUtil.runOnUiThread {
             callLogout()
             promise.safeResolve(null)
         }
+    }
 
     private fun callLogout() =
         try {
@@ -47,6 +49,7 @@ class RNNaverLoginModule(reactContext: ReactApplicationContext) : ReactContextBa
 
     @ReactMethod
     fun login(promise: Promise){
+        // to change it as void type
         UiThreadUtil.runOnUiThread {
             loginPromise = promise
             if (currentActivity == null) {
@@ -84,7 +87,8 @@ class RNNaverLoginModule(reactContext: ReactApplicationContext) : ReactContextBa
       
 
     @ReactMethod
-    fun deleteToken(promise: Promise) =
+    fun deleteToken(promise: Promise){
+        // to change it as void type
         UiThreadUtil.runOnUiThread {
             NidOAuthLogin().callDeleteTokenApi(
                 object : OAuthLoginCallback {
@@ -102,6 +106,8 @@ class RNNaverLoginModule(reactContext: ReactApplicationContext) : ReactContextBa
                 },
             )
         }
+    }
+
 
     companion object {
         private var loginPromise: Promise? = null

--- a/android/src/main/java/com/dooboolab/naverlogin/RNNaverLoginModule.kt
+++ b/android/src/main/java/com/dooboolab/naverlogin/RNNaverLoginModule.kt
@@ -46,7 +46,7 @@ class RNNaverLoginModule(reactContext: ReactApplicationContext) : ReactContextBa
     }
 
     @ReactMethod
-    fun login(promise: Promise) =
+    fun login(promise: Promise){
         UiThreadUtil.runOnUiThread {
             loginPromise = promise
             if (currentActivity == null) {
@@ -80,6 +80,8 @@ class RNNaverLoginModule(reactContext: ReactApplicationContext) : ReactContextBa
                 onLoginFailure(je.localizedMessage)
             }
         }
+    } 
+      
 
     @ReactMethod
     fun deleteToken(promise: Promise) =


### PR DESCRIPTION
```
20:31:07.751  A  java_vm_ext.cc:598] JNI DETECTED ERROR IN APPLICATION: the return type of CallVoidMethodA does not match boolean com.dooboolab.naverlogin.RNNaverLoginModule.login(com.facebook.react.bridge.Promise)
                 java_vm_ext.cc:598]     in call to CallVoidMethodA
                 java_vm_ext.cc:598]     from void com.facebook.jni.NativeRunnable.run()
20:31:07.754  D  app_time_stats: avg=108.95ms min=13.02ms max=677.07ms count=11
20:31:11.608  A  runtime.cc:708] Runtime aborting...
                 runtime.cc:708] Dumping all threads without mutator lock held
                 runtime.cc:708] All threads:
                 runtime.cc:708] DALVIK THREADS (65):
                 runtime.cc:708] "main" prio=10 tid=1 Native
                 runtime.cc:708]   | group="" sCount=1 ucsCount=0 flags=1 obj=0x71fca9b8 self=0xb400006fbfdb6380
                 runtime.cc:708]   | sysTid=10427 nice=-10 cgrp=top-app sched=0/0 handle=0x7157301d20
                 runtime.cc:708]   | state=S schedstat=( 2171437447 539327615 5058 ) utm=146 stm=70 core=1 HZ=100
                 runtime.cc:708]   | stack=0x7fc7cc6000-0x7fc7cc8000 stackSize=8188KB
                 runtime.cc:708]   | held mutexes=
```

아래처럼 로그인 함수를 변경했더니 됩니다. 
참고로 expo prebuild 에서 실행하는 환경입니다. 