### PR TITLE
Update PromiseUtils.kt

### DIFF
--- a/android/src/main/java/com/dooboolab/naverlogin/PromiseUtils.kt
+++ b/android/src/main/java/com/dooboolab/naverlogin/PromiseUtils.kt
@@ -1,7 +1,7 @@
 package com.dooboolab.naverlogin
 
 import android.util.Log
-import com.facebook.react.bridge.ObjectAlreadyConsumedException
+import com.facebook.react.bridge.ReactNoCrashSoftException
 import com.facebook.react.bridge.Promise
 
 /**
@@ -14,7 +14,7 @@ const val TAG = "RNNaverLogin"
 fun Promise.safeResolve(value: Any?) {
     try {
         this.resolve(value)
-    } catch (oce: ObjectAlreadyConsumedException) {
+    } catch (oce: ReactNoCrashSoftException) {
         Log.d(TAG, "Already consumed ${oce.message}")
     }
 }
@@ -40,7 +40,7 @@ fun Promise.safeReject(
 ) {
     try {
         this.reject(code ?: "UNKNOWN_ERROR", message, throwable)
-    } catch (oce: ObjectAlreadyConsumedException) {
+    } catch (oce: ReactNoCrashSoftException) {
         Log.d(TAG, "Already consumed ${oce.message}")
     }
 }


### PR DESCRIPTION
#214 

ObjectAlreadyConsumedException 구현체가 더이상 Public 하지 않습니다.

새롭게 추가된 import com.facebook.react.bridge.ReactNoCrashSoftException 구현체를 사용하는게 맞는 방향인 거 같아 수정합니다.