### PR TITLE
fix: function type in android RNNaverLoginModule.kt file

### DIFF
--- a/android/src/main/java/com/dooboolab/naverlogin/RNNaverLoginModule.kt
+++ b/android/src/main/java/com/dooboolab/naverlogin/RNNaverLoginModule.kt
@@ -18,11 +18,12 @@ class RNNaverLoginModule(reactContext: ReactApplicationContext) : ReactContextBa
     override fun getName() = "RNNaverLogin"
 
     @ReactMethod
-    fun logout(promise: Promise) =
+    fun logout(promise: Promise) {
         UiThreadUtil.runOnUiThread {
             callLogout()
             promise.safeResolve(null)
         }
+    }
 
     private fun callLogout() =
         try {
@@ -46,7 +47,7 @@ class RNNaverLoginModule(reactContext: ReactApplicationContext) : ReactContextBa
     }
 
     @ReactMethod
-    fun login(promise: Promise) =
+    fun login(promise: Promise) {
         UiThreadUtil.runOnUiThread {
             loginPromise = promise
             if (currentActivity == null) {
@@ -80,10 +81,11 @@ class RNNaverLoginModule(reactContext: ReactApplicationContext) : ReactContextBa
                 onLoginFailure(je.localizedMessage)
             }
         }
+    }
 
     @ReactMethod
-    fun deleteToken(promise: Promise) =
-        UiThreadUtil.runOnUiThread {
+    fun deleteToken(promise: Promise) {
+        UiThreadUtil.runOnUiThread {    
             NidOAuthLogin().callDeleteTokenApi(
                 object : OAuthLoginCallback {
                     override fun onSuccess() = promise.safeResolve(null)
@@ -100,6 +102,7 @@ class RNNaverLoginModule(reactContext: ReactApplicationContext) : ReactContextBa
                 },
             )
         }
+    }
 
     companion object {
         private var loginPromise: Promise? = null


### PR DESCRIPTION
# 이슈 번호
#207 

# 문제
이슈와 같이 에러가 발생해 로그인이 불가능한 상황입니다.

# 원인
기존의 함수는 `Kotlin` 표현식 함수를 사용하고 있고, `Kotlin`의 표현식 함수는 자동으로 반환 타입을 추론합니다.
```kotlin
// Kotlin 표현식 함수
@ReactMethod
fun login(promise: Promise) =
    UiThreadUtil.runOnUiThread {
        ...
    }
```
기존의 함수를 보면 내부 `runOnUiThread`의 반환 값을 그대로 `login` 함수의 반환 타입으로 추론합니다.

문제는 `runOnUiThread`는 `Unit(= void)`을 반환하는 것을 보장하지 못하고 종종 `Boolean` 이 될 수도 있습니다. 
-> `runOnUiThread { ... }`가 내부에서 `Boolean`을 반환하는 람다로 잘못 해석되면 React Native 브리지 시 JNI는 이걸 `boolean login(...)` 으로 잘못 인식하게 되며 `boolean login(Promise promise);` 처럼 인식 할 수 있습니다.

그래서 JS 쪽에서 void 메서드를 호출했는데, JNI는 **boolean 리턴을 예상** → **충돌 발생** → **앱 강제 종료**

라는 문제가 발생합니다.

# 해결
`fun [func name]() = …` 함수 형태를 `fun [function name]() { … }` 함수 형태로 변경