### PR TITLE
feat: agreement API 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,13 +202,14 @@ NaverLogin.initialize({
 
 ## API
 
-| Func        |         Param          |            Return             | Description           |
-| :---------- | :--------------------: | :---------------------------: | :-------------------- |
-| initialize  | `NaverLoginInitParams` |            `void`             | 네이버 SDK 초기화     |
-| login       |                        | `Promise<NaverLoginResponse>` | 로그인                |
-| getProfile  |        `String`        | `Promise<GetProfileResponse>` | 프로필 불러오기       |
-| logout      |                        |        `Promise<void>`        | 로그아웃              |
-| deleteToken |                        |        `Promise<void>`        | 네이버 계정 연동 해제 |
+| Func         |         Param          |             Return              | Description                      |
+| :----------- | :--------------------: | :-----------------------------: | :------------------------------- |
+| initialize   | `NaverLoginInitParams` |             `void`              | 네이버 SDK 초기화                |
+| login        |                        |  `Promise<NaverLoginResponse>`  | 로그인                           |
+| getProfile   |        `String`        |  `Promise<GetProfileResponse>`  | 프로필 불러오기                  |
+| getAgreement |        `String`        | `Promise<GetAgreementResponse>` | 약관 동의 대행 동의여부 불러오기 |
+| logout       |                        |         `Promise<void>`         | 로그아웃                         |
+| deleteToken  |                        |         `Promise<void>`         | 네이버 계정 연동 해제            |
 
 ### Type
 
@@ -270,6 +271,22 @@ export interface GetProfileResponse {
     mobile_e164: string | null;
     nickname: string | null;
   };
+}
+```
+
+**GetAgreementResponse**
+
+```ts
+export interface GetAgreementResponse {
+  result: string;
+  accessToken: string;
+  agreementInfos: AgreementInfo[];
+}
+
+export interface AgreementInfo {
+  termCode: string;
+  clientId: string;
+  agreeDate: string;
 }
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,7 @@ const getProfile = (token: string): Promise<GetProfileResponse> => {
     .catch((err) => {
       console.log('getProfile err');
       console.log(err);
+      throw err
     });
 };
 
@@ -130,6 +131,7 @@ const getAgreement = async (token: string): Promise<GetAgreementResponse> => {
     .catch((err) => {
       console.log('getAgreement err');
       console.log(err);
+      throw err
     });
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,11 +107,40 @@ const getProfile = (token: string): Promise<GetProfileResponse> => {
     });
 };
 
+export interface AgreementInfo {termCode: string, clientId: string, agreeDate: string}
+
+export interface GetAgreementResponse {
+  result	: string
+  accessToken: string
+  agreementInfos: AgreementInfo[]
+}
+
+
+const getAgreement = async (token: string): Promise<GetAgreementResponse> => {
+  return fetch('https://openapi.naver.com/v1/nid/agreement', {
+    method: 'GET',
+    headers: {
+      Authorization: 'Bearer ' + token,
+    },
+  })
+    .then((response) => response.json())
+    .then((responseJson) => {
+      return responseJson;
+    })
+    .catch((err) => {
+      console.log('getAgreement err');
+      console.log(err);
+    });
+};
+
+
 const NaverLogin = {
   initialize,
   login,
   logout,
   deleteToken,
   getProfile,
+  getAgreement,
+
 };
 export default NaverLogin;


### PR DESCRIPTION
# 신규 API  추가

[서비스 동의 약관 대행](https://developers.naver.com/docs/login/devguide/devguide.md#5-2-1-서비스-약관-동의-대행) 기능을 사용하기 위한 API를 추가합니다.