### PR TITLE
Don't silently drop invalid network status code from `getAgreement`, `getProfile`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,32 +36,6 @@ export interface NaverLoginResponse {
   };
 }
 
-export interface NaverApiError {
-  timestamp: number;
-  status: number;
-  error: string;
-  path: string;
-}
-
-const handleNaverApiResponse = async <T>(response: Response): Promise<T> => {
-  if (!response.ok) {
-    try {
-      const errorData: NaverApiError = await response.json();
-      throw errorData;
-    } catch (error) {
-      const parseError: NaverApiError = {
-        timestamp: Date.now(),
-        status: response.status,
-        error: `네이버 API 호출 실패 (${response.status})`,
-        path: response.url,
-      };
-      throw parseError;
-    }
-  }
-
-  return response.json();
-};
-
 const initialize = ({
   appName,
   consumerKey,
@@ -115,6 +89,32 @@ export interface GetProfileResponse {
     nickname: string | null;
   };
 }
+
+export interface NaverApiError {
+  timestamp: number;
+  status: number;
+  error: string;
+  path: string;
+}
+
+const handleNaverApiResponse = async <T>(response: Response): Promise<T> => {
+  if (!response.ok) {
+    try {
+      const errorData: NaverApiError = await response.json();
+      throw errorData;
+    } catch (error) {
+      const parseError: NaverApiError = {
+        timestamp: Date.now(),
+        status: response.status,
+        error: `네이버 API 호출 실패 (${response.status})`,
+        path: response.url,
+      };
+      throw parseError;
+    }
+  }
+
+  return response.json();
+};
 
 const getProfile = (token: string): Promise<GetProfileResponse> => {
   return fetch('https://openapi.naver.com/v1/nid/me', {

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,38 +97,31 @@ export interface NaverApiError {
   path: string;
 }
 
-const handleNaverApiResponse = async <T>(response: Response): Promise<T> => {
+const handleNaverApiResponse = async (response: Response) => {
   if (!response.ok) {
     try {
-      const errorData: NaverApiError = await response.json();
-      throw errorData;
+      throw await response.json();
     } catch (error) {
-      const parseError: NaverApiError = {
+      throw {
         timestamp: Date.now(),
         status: response.status,
         error: `네이버 API 호출 실패 (${response.status})`,
         path: response.url,
-      };
-      throw parseError;
+      } satisfies NaverApiError;
     }
   }
 
   return response.json();
 };
 
-const getProfile = (token: string): Promise<GetProfileResponse> => {
-  return fetch('https://openapi.naver.com/v1/nid/me', {
+const getProfile = async (token: string): Promise<GetProfileResponse> => {
+  const response = await fetch('https://openapi.naver.com/v1/nid/me', {
     method: 'GET',
     headers: {
-      Authorization: 'Bearer ' + token,
+      Authorization: `Bearer ${token}`,
     },
-  })
-    .then((response) => handleNaverApiResponse<GetProfileResponse>(response))
-    .then((responseJson) => responseJson)
-    .catch((err) => {
-      console.log('getProfile err', err);
-      throw err;
-    });
+  });
+  return await handleNaverApiResponse(response);
 };
 
 export interface AgreementInfo {
@@ -144,18 +137,13 @@ export interface GetAgreementResponse {
 }
 
 const getAgreement = async (token: string): Promise<GetAgreementResponse> => {
-  return fetch('https://openapi.naver.com/v1/nid/agreement', {
+  const response = await fetch('https://openapi.naver.com/v1/nid/agreement', {
     method: 'GET',
     headers: {
-      Authorization: 'Bearer ' + token,
+      Authorization: `Bearer ${token}`,
     },
-  })
-    .then((response) => handleNaverApiResponse<GetAgreementResponse>(response))
-    .then((responseJson) => responseJson)
-    .catch((err) => {
-      console.log('getAgreement err', err);
-      throw err;
-    });
+  });
+  return handleNaverApiResponse(response);
 };
 
 const NaverLogin = {


### PR DESCRIPTION
이전에 **getAgreement** 함수를 추가하고 사용하던 도중, 특이 케이스를 발견했습니다.

- 기존에 네아로를 통해 가입한 회원일 것.
- 네아로 플러스를 이용하여 약관 동의 대행을 추가할 것.
- 기존 유저는 약관 동의 페이지를 노출시켜주지 않음 (네이버의 문제?)
- 기존 유저로  약관 동의 정보를 가져올때 getAgreement는 404 던져줍니다.
💥 문제가 발생합니다.

fetch 함수는 404라도 throw하지 않기 때문에 이 부분을 개선합니다.