### PR TITLE
fix: fix android init error

### DIFF
--- a/android/src/main/java/com/dooboolab/naverlogin/RNNaverLoginModule.kt
+++ b/android/src/main/java/com/dooboolab/naverlogin/RNNaverLoginModule.kt
@@ -37,13 +37,15 @@ class RNNaverLoginModule(reactContext: ReactApplicationContext) : ReactContextBa
         consumerKey: String,
         consumerSecret: String,
         appName: String,
-    ) = UiThreadUtil.runOnUiThread {
-        NaverIdLoginSDK.initialize(
-            reactApplicationContext,
-            clientId = consumerKey,
-            clientSecret = consumerSecret,
-            clientName = appName,
-        )
+    ) {
+        UiThreadUtil.runOnUiThread {
+            NaverIdLoginSDK.initialize(
+                reactApplicationContext,
+                clientId = consumerKey,
+                clientSecret = consumerSecret,
+                clientName = appName,
+            )
+        }
     }
 
     @ReactMethod


### PR DESCRIPTION
## Android Bug Fix

android bridgeless turbo module 환경에서 init 할때 앱 크래시가 발생합니다. 
initialize 메서드 리턴타입이 void 가 되도록 변경했습니다. 
수정 후 문제가 없음을 확인했습니다. 

<img width="2411" height="357" alt="Screenshot 2025-08-02 at 9 43 25 PM" src="https://github.com/user-attachments/assets/0c793d6a-82b0-4cfc-b782-ae6bf97858ca" />


```json
"react-native": "0.80.2",
"@react-native-seoul/naver-login": "4.2.0",
```

