### PR TITLE
fix: support react native 0.81

### DIFF
--- a/android/src/main/java/com/dooboolab/naverlogin/RNNaverLoginModule.kt
+++ b/android/src/main/java/com/dooboolab/naverlogin/RNNaverLoginModule.kt
@@ -52,13 +52,14 @@ class RNNaverLoginModule(reactContext: ReactApplicationContext) : ReactContextBa
     fun login(promise: Promise) {
         UiThreadUtil.runOnUiThread {
             loginPromise = promise
-            if (currentActivity == null) {
+            val activity = reactApplicationContext.currentActivity
+            if (activity == null) {
                 onLoginFailure("현재 실행중인 Activity 를 찾을 수 없습니다")
                 return@runOnUiThread
             }
             try {
                 NaverIdLoginSDK.authenticate(
-                    currentActivity!!,
+                    activity,
                     object : OAuthLoginCallback {
                         override fun onSuccess() {
                             onLoginSuccess()

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -27,7 +27,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
-newArchEnabled=true
+newArchEnabled=false
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
 hermesEnabled=true


### PR DESCRIPTION
React Native 0.81 버전부터 `currentActivity` 에 대한 접근이 불가능합니다. 

<img width="766" height="191" alt="Screenshot 2025-08-29 at 2 35 31 PM" src="https://github.com/user-attachments/assets/68c74b87-acea-434d-a942-ce7a6fbd3ea7" />

<img width="915" height="382" alt="Screenshot 2025-08-29 at 2 34 38 PM" src="https://github.com/user-attachments/assets/1ebe776b-3479-4ef7-9fbf-4987b993e140" />

`reactApplicationContext` 를 통해서 Activity 에 접근하고자 합니다. 

타 라이브러리 수정 예시입니다. 

https://github.com/gronxb/hot-updater/pull/515
